### PR TITLE
Update Cargo.lock With 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "nu_plugin_net"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "nu-plugin",
  "nu-protocol",


### PR DESCRIPTION
Cargo can't build with the frozen flag since lock and toml are not consistent.