### PR TITLE
update to 0.97.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ name = "nu_plugin_net"
 [lib]
 
 [dependencies]
-nu-plugin = "0.97.1"
-nu-protocol = { version = "0.97.1", features = ["plugin"] }
+nu-plugin = "0.97.2"
+nu-protocol = { version = "0.97.2", features = ["plugin"] }
 pnet = "0.35.0"
 
 # The profile that 'cargo dist' will build with

--- a/src/inf.rs
+++ b/src/inf.rs
@@ -75,7 +75,7 @@ impl SimplePluginCommand for InterfacesCommand {
         "net"
     }
 
-    fn usage(&self) -> &str {
+    fn description(&self) -> &str {
         "Enumerate network interfaces on the current host"
     }
 


### PR DESCRIPTION
Closes #24 

Note that Cargo.lock for the branch is stale. It will be updated, and this PR merged, as soon as 0.97.2 is released.